### PR TITLE
Print subject in case of x509 client cert auth

### DIFF
--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -182,7 +182,8 @@ func (o *WhoAmIOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(cert.Subject)
+		username := cert.Subject.CommonName
+		fmt.Println(username)
 		return nil
 	}
 


### PR DESCRIPTION
Print subject in case of x509 client cert auth, instead of `kubecfg:certauth:admin`.

Fixes #9 

As an example, I chose to simply print the client certificate subject.

#### Example
```
$ kubectl-whoami
CN=kubernetes-admin,O=system:masters
```
But I'm ok with any other format; please tell me your preference.