### PR TITLE
add exec provider support

### DIFF
--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -180,7 +180,7 @@ func (o *WhoAmIOptions) Run() error {
 		return nil
 	}
 
-	return nil
+	return fmt.Errorf("unsupported auth mechanism. kindly report a ticket at https://github.com/rajatjindal/kubectl-whoami")
 }
 
 func (o *WhoAmIOptions) getToken() (string, error) {

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -149,7 +149,7 @@ func (o *WhoAmIOptions) Run() error {
 		}
 	}
 
-	if token == "" && config.AuthProvider != nil {
+	if token == "" && (config.AuthProvider != nil || config.ExecProvider != nil) {
 		token, err = o.getToken()
 		if err != nil {
 			return err


### PR DESCRIPTION
- add support for ExecProvider
- return error if unsupported auth mechanism found